### PR TITLE
Remove useless switch statements

### DIFF
--- a/src/bun.zig
+++ b/src/bun.zig
@@ -146,16 +146,11 @@ pub const fmt = struct {
             }
 
             const mags_si = " KMGTPEZY";
-            const mags_iec = " KMGTPEZY";
 
             const log2 = math.log2(value);
             const magnitude = @min(log2 / comptime math.log2(1000), mags_si.len - 1);
             const new_value = math.lossyCast(f64, value) / math.pow(f64, 1000, math.lossyCast(f64, magnitude));
-            const suffix = switch (1000) {
-                1000 => mags_si[magnitude],
-                1024 => mags_iec[magnitude],
-                else => unreachable,
-            };
+            const suffix = mags_si[magnitude];
 
             if (suffix == ' ') {
                 try fmt.formatFloatDecimal(new_value / 1000.0, .{ .precision = 2 }, writer);
@@ -164,11 +159,7 @@ pub const fmt = struct {
                 try fmt.formatFloatDecimal(new_value, .{ .precision = if (std.math.approxEqAbs(f64, new_value, @trunc(new_value), 0.100)) @as(usize, 1) else @as(usize, 2) }, writer);
             }
 
-            const buf = switch (1000) {
-                1000 => &[_]u8{ ' ', suffix, 'B' },
-                1024 => &[_]u8{ ' ', suffix, 'i', 'B' },
-                else => unreachable,
-            };
+            const buf = &[_]u8{ ' ', suffix, 'B' };
             return writer.writeAll(buf);
         }
     };


### PR DESCRIPTION
It appears that at some point it was decided that there wouldn't be a difference in formatting 1000 based suffixes and 1024 based suffixes but this code was never cleaned up after the switch statement was hardcoded. I'm surprised that Zig doesn't care about unreachable code.

### What does this PR do?
Removes dead code

### How did you verify your code works?
Nothing that is executed is changed.
